### PR TITLE
feat: support custom openai endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ npm run dev
 
 Open [http://localhost:3000/lexeme/](http://localhost:3000/lexeme/) with your browser to see the result.
 
+You may specify a custom API endpoint by setting `OPENAI_BASE_URL` environment variable.
+
 ## Deploying on Kubernetes
+
 Update `OPENAI_API_KEY` in `k8s.yml` and then
+
 ```bash
 skaffold run
 # or

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -1,8 +1,9 @@
 export default async function handler(req, res) {
   try {
     const { key } = req.body
+    const openaiBaseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 
-    const response = await fetch(`https://api.openai.com/v1/models`, {
+    const response = await fetch(`${openaiBaseUrl }/models`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${key && key != "" ? key : process.env.OPENAI_API_KEY}`,

--- a/pages/api/writer.ts
+++ b/pages/api/writer.ts
@@ -16,6 +16,8 @@ export default async function handler(
   try {
     const { task, selection, before, after } = req.body;
 
+    const openaiBaseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+
 
     // const tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
 
@@ -34,7 +36,7 @@ export default async function handler(
       content: selection
     }]
     
-    const response = await fetch(`https://api.openai.com/v1/chat/completions`, {
+    const response = await fetch(`${openaiBaseUrl}/chat/completions`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${ process.env.OPENAI_API_KEY }`,

--- a/pages/api/writer2.ts
+++ b/pages/api/writer2.ts
@@ -10,12 +10,13 @@ type Data = {
 import type { TaskType } from '@/types/data';
 import  { TasksMap } from '@/types/data';
 const { createParser, ParsedEvent, ReconnectInterval } = require("eventsource-parser");
+const openaiBaseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 
 
 
  async function inference(messages, apiKey, modelId, temperature) {
     console.log("START REQUEST")
-    // const response = await fetch(`https://api.openai.com/v1/chat/completions`, {
+    // const response = await fetch(`${openaiBaseUrl}/chat/completions`, {
     //   headers: {
     //     'Content-Type': 'application/json',
     //     Authorization: `Bearer ${ process.env.OPENAI_API_KEY }`,
@@ -46,7 +47,7 @@ const { createParser, ParsedEvent, ReconnectInterval } = require("eventsource-pa
         temperature: parseFloat(temperature),
         stream: true
       })
-    const resx = await fetch("https://api.openai.com/v1/chat/completions", {
+    const resx = await fetch(`${openaiBaseUrl}/chat/completions`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`
@@ -54,7 +55,7 @@ const { createParser, ParsedEvent, ReconnectInterval } = require("eventsource-pa
         method: "POST",
         body: payload
       });
-      console.log(`curl -X POST "https://api.openai.com/v1/chat/completions" -H "Authorization: Bearer ${apiKey}" -H "Content-Type: application/json" -d '${payload}'`)
+      console.log(`curl -X POST "${openaiBaseUrl}/chat/completions" -H "Authorization: Bearer ${apiKey}" -H "Content-Type: application/json" -d '${payload}'`)
     // // console.log("Response content:", response.body)
     // const data = await response.json()
     // console.log("Response content:", data)


### PR DESCRIPTION
- Allow setting a custom OpenAI API endpoint URL.

Workaround for #1 

Tested working:

<img width="885" alt="image" src="https://github.com/pagebrain/lexeme/assets/862951/b9b47c11-68bb-4341-ab92-d0c55f627b60">


```
curl -X POST "https://textgen.local/v1/chat/completions" -H "Authorization: Bearer sf-1234567890" -H "Content-Type: application/json" -d '{"model":"gpt-3.5-turbo","messages":[{"role":"system","content":"<|im_start|>system\nYou are an assistant helping a user write a document. Follow the user's instructions carefully.  Respond using markdown.\n<|im_end|>\nBrainstorm ideas for the following text."},{"role":"user","content":""},{"role":"user","content":"ideas for a film script"}],"max_tokens":500,"temperature":0.5,"stream":true}'
```